### PR TITLE
Feature/frontend session select product

### DIFF
--- a/backend/src/VendingMachine/Machine/UI/Http/Controller/SelectProductController.php
+++ b/backend/src/VendingMachine/Machine/UI/Http/Controller/SelectProductController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Machine\UI\Http\Controller;
+
+use App\VendingMachine\Session\Application\SelectProduct\SelectProductCommand;
+use App\VendingMachine\Session\Application\SelectProduct\SelectProductCommandHandler;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SelectProductController extends AbstractController
+{
+    public function __construct(
+        private readonly SelectProductCommandHandler $handler,
+        #[Autowire('%app.machine_id%')] private readonly string $machineId,
+    ) {
+    }
+
+    #[Route('/machine/session/product', name: 'api_machine_session_select_product', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = $this->decodeRequest($request);
+
+        $result = $this->handler->handle(
+            new SelectProductCommand(
+                machineId: $this->machineId,
+                sessionId: $payload['session_id'],
+                productId: $payload['product_id'],
+            )
+        );
+
+        return new JsonResponse([
+            'machine_id' => $this->machineId,
+            'session' => [
+                'id' => $result->sessionId,
+                'state' => $result->state,
+                'balance_cents' => $result->balanceCents,
+                'inserted_coins' => $result->insertedCoins,
+                'selected_product_id' => $result->selectedProductId,
+            ],
+        ], Response::HTTP_OK);
+    }
+
+    /**
+     * @return array{session_id: string, product_id: string}
+     */
+    private function decodeRequest(Request $request): array
+    {
+        $data = json_decode($request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!isset($data['session_id']) || !is_string($data['session_id'])) {
+            throw new BadRequestHttpException('Missing or invalid "session_id".');
+        }
+
+        if (!isset($data['product_id']) || !is_string($data['product_id'])) {
+            throw new BadRequestHttpException('Missing or invalid "product_id".');
+        }
+
+        return [
+            'session_id' => $data['session_id'],
+            'product_id' => $data['product_id'],
+        ];
+    }
+}

--- a/backend/src/VendingMachine/Session/Application/SelectProduct/SelectProductCommand.php
+++ b/backend/src/VendingMachine/Session/Application/SelectProduct/SelectProductCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Session\Application\SelectProduct;
+
+final class SelectProductCommand
+{
+    public function __construct(
+        public readonly string $machineId,
+        public readonly string $sessionId,
+        public readonly string $productId,
+    ) {
+    }
+}

--- a/backend/src/VendingMachine/Session/Application/SelectProduct/SelectProductCommandHandler.php
+++ b/backend/src/VendingMachine/Session/Application/SelectProduct/SelectProductCommandHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Session\Application\SelectProduct;
+
+use App\VendingMachine\Machine\Infrastructure\Mongo\Document\ActiveSessionDocument;
+use App\VendingMachine\Product\Domain\ValueObject\ProductId;
+use App\VendingMachine\Session\Application\StartSession\StartSessionResult;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use DomainException;
+
+final class SelectProductCommandHandler
+{
+    public function __construct(
+        private readonly DocumentManager $documentManager,
+    ) {
+    }
+
+    public function handle(SelectProductCommand $command): StartSessionResult
+    {
+        /** @var ActiveSessionDocument|null $document */
+        $document = $this->documentManager->find(ActiveSessionDocument::class, $command->machineId);
+
+        if (null === $document || null === $document->sessionId()) {
+            throw new DomainException('No active session found for this machine.');
+        }
+
+        if ($document->sessionId() !== $command->sessionId) {
+            throw new DomainException('The provided session id does not match the active session.');
+        }
+
+        $session = $document->toVendingSession();
+        $session->selectProduct(ProductId::fromString($command->productId));
+
+        $document->applySession($session);
+
+        $this->documentManager->flush();
+
+        return new StartSessionResult(
+            sessionId: $session->id()->value(),
+            state: $session->state()->value,
+            balanceCents: $session->balance()->amountInCents(),
+            insertedCoins: $session->insertedCoins()->toArray(),
+            selectedProductId: $session->selectedProductId()?->value(),
+        );
+    }
+}

--- a/backend/tests/Unit/VendingMachine/Session/Application/SelectProductCommandHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Session/Application/SelectProductCommandHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\VendingMachine\Session\Application;
+
+use App\VendingMachine\Machine\Infrastructure\Mongo\Document\ActiveSessionDocument;
+use App\VendingMachine\Session\Application\SelectProduct\SelectProductCommand;
+use App\VendingMachine\Session\Application\SelectProduct\SelectProductCommandHandler;
+use App\VendingMachine\Session\Domain\ValueObject\VendingSessionState;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use DomainException;
+use PHPUnit\Framework\TestCase;
+
+final class SelectProductCommandHandlerTest extends TestCase
+{
+    public function testItAssignsSelectedProductToActiveSession(): void
+    {
+        $document = new ActiveSessionDocument(
+            machineId: 'machine-1',
+            sessionId: 'session-1',
+            state: VendingSessionState::Collecting->value,
+            balanceCents: 0,
+            insertedCoins: [],
+            selectedProductId: null,
+            changePlan: null,
+        );
+
+        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager->expects(self::once())
+            ->method('find')
+            ->with(ActiveSessionDocument::class, 'machine-1')
+            ->willReturn($document);
+
+        $documentManager->expects(self::once())
+            ->method('flush');
+
+        $handler = new SelectProductCommandHandler($documentManager);
+
+        $result = $handler->handle(new SelectProductCommand('machine-1', 'session-1', 'product-1'));
+
+        self::assertSame('product-1', $document->selectedProductId());
+        self::assertSame('product-1', $result->selectedProductId);
+    }
+
+    public function testItFailsWhenActiveSessionIsMissing(): void
+    {
+        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager->expects(self::once())
+            ->method('find')
+            ->with(ActiveSessionDocument::class, 'machine-1')
+            ->willReturn(null);
+
+        $handler = new SelectProductCommandHandler($documentManager);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('No active session found for this machine.');
+
+        $handler->handle(new SelectProductCommand('machine-1', 'session-1', 'product-1'));
+    }
+
+    public function testItFailsWhenSessionIdDoesNotMatch(): void
+    {
+        $document = new ActiveSessionDocument(
+            machineId: 'machine-1',
+            sessionId: 'session-2',
+            state: VendingSessionState::Collecting->value,
+            balanceCents: 0,
+            insertedCoins: [],
+            selectedProductId: null,
+            changePlan: null,
+        );
+
+        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager->expects(self::once())
+            ->method('find')
+            ->with(ActiveSessionDocument::class, 'machine-1')
+            ->willReturn($document);
+
+        $handler = new SelectProductCommandHandler($documentManager);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('The provided session id does not match the active session.');
+
+        $handler->handle(new SelectProductCommand('machine-1', 'session-1', 'product-1'));
+    }
+}

--- a/frontend/src/modules/machine/api/selectMachineProduct.ts
+++ b/frontend/src/modules/machine/api/selectMachineProduct.ts
@@ -1,0 +1,33 @@
+import { postJson } from '@/core/api/httpClient'
+import {
+  mapSessionResponse,
+  type MachineSessionResponse,
+  type MachineSessionResult,
+} from '@/modules/machine/api/startMachineSession'
+
+type SelectMachineProductRequest = {
+  sessionId: string
+  productId: string
+}
+
+type SelectMachineProductPayload = {
+  session_id: string
+  product_id: string
+}
+
+const toPayload = ({ sessionId, productId }: SelectMachineProductRequest): SelectMachineProductPayload => ({
+  session_id: sessionId,
+  product_id: productId,
+})
+
+export async function selectMachineProduct({
+  sessionId,
+  productId,
+}: SelectMachineProductRequest): Promise<MachineSessionResult> {
+  const response = await postJson<MachineSessionResponse>('/machine/session/product', toPayload({
+    sessionId,
+    productId,
+  }))
+
+  return mapSessionResponse(response)
+}

--- a/frontend/src/modules/machine/views/MachineDashboard.vue
+++ b/frontend/src/modules/machine/views/MachineDashboard.vue
@@ -222,9 +222,23 @@ export default defineComponent({
         return false
       }
 
+      const previousSlot = this.selectedSlotCode
       this.selectedSlotCode = slotCode
-      // TODO: call backend when slot selection should update the session
-      return true
+
+      const selected = this.productCards.find((item) => item.slotCode === slotCode)
+
+      if (!selected || !selected.productId || selected.status !== 'available') {
+        return true
+      }
+
+      try {
+        await this.machineStore.selectProduct(selected.productId)
+        return true
+      } catch (error) {
+        console.error('Failed to update selected product', error)
+        this.selectedSlotCode = previousSlot
+        return false
+      }
     },
     async handleConfirmCode(): Promise<void> {
       if (!this.enteredCode) {


### PR DESCRIPTION
- Added the POST /api/machine/session/product endpoint to validate session_id/product_id, delegate to the new command handler, and return the refreshed session snapshot.

- Introduced the SelectProductCommand + handler to persist the selected product in the active session projection, with unit tests covering the happy path, missing session, and mismatched session id.

- Reused the session mapper on the frontend, exposed selectMachineProduct, and upgraded the Pinia store to update machine state, loading, and error indicators whenever a product is selected.

- Refined the dashboard UX so invalid selections revert to the idle message after 5 s, previous valid slots are restored automatically, and partial keypad input preserves the current selection until a full code is confirmed.