### PR TITLE
Feature/coin return

### DIFF
--- a/backend/src/VendingMachine/Machine/UI/Http/Controller/ReturnCoinsController.php
+++ b/backend/src/VendingMachine/Machine/UI/Http/Controller/ReturnCoinsController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Machine\UI\Http\Controller;
+
+use App\VendingMachine\Session\Application\ReturnCoins\ReturnCoinsCommand;
+use App\VendingMachine\Session\Application\ReturnCoins\ReturnCoinsCommandHandler;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ReturnCoinsController extends AbstractController
+{
+    public function __construct(
+        private readonly ReturnCoinsCommandHandler $handler,
+        #[Autowire('%app.machine_id%')] private readonly string $machineId,
+    ) {
+    }
+
+    #[Route('/machine/session/coins/return', name: 'api_machine_session_return_coins', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = $this->decodeRequest($request);
+
+        $result = $this->handler->handle(
+            new ReturnCoinsCommand(
+                machineId: $this->machineId,
+                sessionId: $payload['session_id'],
+            )
+        );
+
+        return new JsonResponse([
+            'machine_id' => $this->machineId,
+            'session' => [
+                'id' => $result->sessionId,
+                'state' => $result->state,
+                'balance_cents' => $result->balanceCents,
+                'inserted_coins' => $result->insertedCoins,
+                'selected_product_id' => $result->selectedProductId,
+                'selected_slot_code' => $result->selectedSlotCode,
+            ],
+            'returned_coins' => $result->returnedCoins,
+        ], Response::HTTP_OK);
+    }
+
+    /**
+     * @return array{session_id: string}
+     */
+    private function decodeRequest(Request $request): array
+    {
+        $data = json_decode($request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!isset($data['session_id']) || !is_string($data['session_id'])) {
+            throw new BadRequestHttpException('Missing or invalid "session_id".');
+        }
+
+        return [
+            'session_id' => $data['session_id'],
+        ];
+    }
+}

--- a/backend/src/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommand.php
+++ b/backend/src/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Session\Application\ReturnCoins;
+
+final class ReturnCoinsCommand
+{
+    public function __construct(
+        public readonly string $machineId,
+        public readonly string $sessionId,
+    ) {
+    }
+}

--- a/backend/src/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommandHandler.php
+++ b/backend/src/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommandHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Session\Application\ReturnCoins;
+
+use App\VendingMachine\Machine\Infrastructure\Mongo\Document\ActiveSessionDocument;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use DomainException;
+
+final class ReturnCoinsCommandHandler
+{
+    public function __construct(private readonly DocumentManager $documentManager)
+    {
+    }
+
+    public function handle(ReturnCoinsCommand $command): ReturnCoinsResult
+    {
+        /** @var ActiveSessionDocument|null $document */
+        $document = $this->documentManager->find(ActiveSessionDocument::class, $command->machineId);
+
+        if (null === $document || null === $document->sessionId()) {
+            throw new DomainException('No active session found for this machine.');
+        }
+
+        if ($document->sessionId() !== $command->sessionId) {
+            throw new DomainException('The provided session id does not match the active session.');
+        }
+
+        $session = $document->toVendingSession();
+        $returnedCoins = $session->returnCoins();
+
+        $document->applySession($session);
+
+        $this->documentManager->flush();
+
+        return new ReturnCoinsResult(
+            sessionId: $session->id()->value(),
+            state: $session->state()->value,
+            balanceCents: $session->balance()->amountInCents(),
+            insertedCoins: $session->insertedCoins()->toArray(),
+            selectedProductId: $session->selectedProductId()?->value(),
+            selectedSlotCode: $document->selectedSlotCode(),
+            returnedCoins: $returnedCoins->toArray(),
+        );
+    }
+}

--- a/backend/src/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsResult.php
+++ b/backend/src/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\VendingMachine\Session\Application\ReturnCoins;
+
+final class ReturnCoinsResult
+{
+    /**
+     * @param array<int, int> $insertedCoins
+     * @param array<int, int> $returnedCoins
+     */
+    public function __construct(
+        public readonly string $sessionId,
+        public readonly string $state,
+        public readonly int $balanceCents,
+        public readonly array $insertedCoins,
+        public readonly ?string $selectedProductId,
+        public readonly ?string $selectedSlotCode,
+        public readonly array $returnedCoins,
+    ) {
+    }
+}

--- a/backend/src/VendingMachine/Session/Domain/VendingSession.php
+++ b/backend/src/VendingMachine/Session/Domain/VendingSession.php
@@ -125,6 +125,21 @@ final class VendingSession
         $this->selectedProductId = null;
     }
 
+    public function returnCoins(): CoinBundle
+    {
+        $this->ensureStateIs(VendingSessionState::Collecting);
+
+        $coins = $this->insertedCoins;
+
+        $this->insertedCoins = CoinBundle::empty();
+        $this->balance = Money::fromCents(0);
+        $this->selectedProductId = null;
+
+        $this->ensureStateConsistency();
+
+        return $coins;
+    }
+
     public function approvePurchase(Money $price, CoinBundle $change): void
     {
         $this->ensureStateIs(VendingSessionState::Collecting);

--- a/backend/tests/Unit/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommandHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommandHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\VendingMachine\Session\Application\ReturnCoins;
+
+use App\VendingMachine\Machine\Infrastructure\Mongo\Document\ActiveSessionDocument;
+use App\VendingMachine\Session\Application\ReturnCoins\ReturnCoinsCommand;
+use App\VendingMachine\Session\Application\ReturnCoins\ReturnCoinsCommandHandler;
+use App\VendingMachine\Session\Domain\ValueObject\VendingSessionState;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use DomainException;
+use PHPUnit\Framework\TestCase;
+
+final class ReturnCoinsCommandHandlerTest extends TestCase
+{
+    public function testItReturnsInsertedCoinsAndResetsSession(): void
+    {
+        $document = new ActiveSessionDocument(
+            machineId: 'machine-1',
+            sessionId: 'session-1',
+            state: VendingSessionState::Collecting->value,
+            balanceCents: 125,
+            insertedCoins: [100 => 1, 25 => 1],
+            selectedProductId: 'product-1',
+            selectedSlotCode: 'A1',
+            changePlan: null,
+        );
+
+        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager->expects(self::once())
+            ->method('find')
+            ->with(ActiveSessionDocument::class, 'machine-1')
+            ->willReturn($document);
+
+        $documentManager->expects(self::once())
+            ->method('flush');
+
+        $handler = new ReturnCoinsCommandHandler($documentManager);
+
+        $result = $handler->handle(new ReturnCoinsCommand('machine-1', 'session-1'));
+
+        self::assertSame(1, $result->returnedCoins[100] ?? null);
+        self::assertSame(1, $result->returnedCoins[25] ?? null);
+        self::assertSame(0, $result->balanceCents);
+        self::assertNull($result->selectedProductId);
+        self::assertNull($result->selectedSlotCode);
+        self::assertSame([], $result->insertedCoins);
+    }
+
+    public function testItFailsWhenActiveSessionIsMissing(): void
+    {
+        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager->expects(self::once())
+            ->method('find')
+            ->with(ActiveSessionDocument::class, 'machine-1')
+            ->willReturn(null);
+
+        $handler = new ReturnCoinsCommandHandler($documentManager);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('No active session found for this machine.');
+
+        $handler->handle(new ReturnCoinsCommand('machine-1', 'session-1'));
+    }
+
+    public function testItFailsWhenSessionIdDoesNotMatch(): void
+    {
+        $document = new ActiveSessionDocument(
+            machineId: 'machine-1',
+            sessionId: 'session-2',
+            state: VendingSessionState::Collecting->value,
+            balanceCents: 0,
+            insertedCoins: [],
+            selectedProductId: null,
+            selectedSlotCode: null,
+            changePlan: null,
+        );
+
+        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager->expects(self::once())
+            ->method('find')
+            ->with(ActiveSessionDocument::class, 'machine-1')
+            ->willReturn($document);
+
+        $handler = new ReturnCoinsCommandHandler($documentManager);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('The provided session id does not match the active session.');
+
+        $handler->handle(new ReturnCoinsCommand('machine-1', 'session-1'));
+    }
+}

--- a/frontend/src/modules/machine/api/returnMachineCoins.ts
+++ b/frontend/src/modules/machine/api/returnMachineCoins.ts
@@ -1,0 +1,41 @@
+import { postJson } from '@/core/api/httpClient'
+import {
+  mapSessionResponse,
+  type MachineSessionResponse,
+  type MachineSessionResult,
+} from '@/modules/machine/api/startMachineSession'
+
+export interface ReturnMachineCoinsResult extends MachineSessionResult {
+  returnedCoins: Record<number, number>
+}
+
+interface ReturnMachineCoinsPayload {
+  session_id: string
+}
+
+interface ReturnMachineCoinsResponse extends MachineSessionResponse {
+  returned_coins: Record<string, number>
+}
+
+const toPayload = (sessionId: string): ReturnMachineCoinsPayload => ({
+  session_id: sessionId,
+})
+
+const toNumberRecord = (input: Record<string, number>): Record<number, number> =>
+  Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [Number(key), value])
+  )
+
+export async function returnMachineCoins(sessionId: string): Promise<ReturnMachineCoinsResult> {
+  const response = await postJson<ReturnMachineCoinsResponse>(
+    '/machine/session/coins/return',
+    toPayload(sessionId)
+  )
+
+  const sessionResult = mapSessionResponse(response)
+
+  return {
+    ...sessionResult,
+    returnedCoins: toNumberRecord(response.returned_coins),
+  }
+}

--- a/frontend/src/modules/machine/components/MachineControlPanel.vue
+++ b/frontend/src/modules/machine/components/MachineControlPanel.vue
@@ -20,18 +20,6 @@
         </div>
       </dl>
 
-      <div
-        v-if="statusMessage"
-        class="product-display__message"
-        :class="{
-          'product-display__message--error': statusTone === 'error',
-          'product-display__message--info': statusTone === 'info',
-          'product-display__message--warning': statusTone === 'warning',
-        }"
-      >
-        {{ statusMessage }}
-      </div>
-
       <div v-if="selectionState === 'idle' && !statusMessage" class="product-display__marquee">
         <div class="marquee-track">
           <span>Select a product to start the sale · </span>
@@ -43,6 +31,11 @@
       <div v-else-if="selectionState === 'unavailable'" class="product-display__warning">
         <span class="warning-icon">!</span>
         <p>Product unavailable</p>
+      </div>
+
+      <div v-else-if="statusMessage" :class="overlayClasses">
+        <span v-if="statusTone !== 'info'" class="overlay-icon">!</span>
+        <p>{{ statusMessage }}</p>
       </div>
     </div>
 
@@ -253,6 +246,14 @@ export default defineComponent({
 
       return null
     },
+    overlayClasses(): Record<string, boolean> {
+      return {
+        'product-display__overlay': true,
+        'product-display__overlay--error': this.statusTone === 'error',
+        'product-display__overlay--info': this.statusTone === 'info',
+        'product-display__overlay--warning': this.statusTone === 'warning',
+      }
+    },
   },
   methods: {
     handleCoinButton(value: number): void {
@@ -434,6 +435,60 @@ export default defineComponent({
   justify-content: center;
   font-size: 1.4rem;
   box-shadow: 0 8px 18px rgba(249, 115, 22, 0.35);
+}
+
+.product-display__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  border-radius: 16px;
+  padding: 1.25rem;
+  text-align: center;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+  pointer-events: none;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+}
+
+.product-display__overlay--error {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.product-display__overlay--info {
+  background: rgba(129, 140, 248, 0.18);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: #cdd5ff;
+}
+
+.product-display__overlay--warning {
+  background: rgba(251, 191, 36, 0.18);
+  border-color: rgba(251, 191, 36, 0.4);
+  color: #fde68a;
+}
+
+.product-display__overlay p {
+  margin: 0;
+}
+
+.overlay-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f59e0b 0%, #fbbf24 100%);
+  color: #1f2937;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  box-shadow: 0 8px 18px rgba(251, 191, 36, 0.35);
 }
 
 .marquee-track {

--- a/frontend/src/modules/machine/components/MachineControlPanel.vue
+++ b/frontend/src/modules/machine/components/MachineControlPanel.vue
@@ -20,7 +20,19 @@
         </div>
       </dl>
 
-      <div v-if="selectionState === 'idle'" class="product-display__marquee">
+      <div
+        v-if="statusMessage"
+        class="product-display__message"
+        :class="{
+          'product-display__message--error': statusTone === 'error',
+          'product-display__message--info': statusTone === 'info',
+          'product-display__message--warning': statusTone === 'warning',
+        }"
+      >
+        {{ statusMessage }}
+      </div>
+
+      <div v-if="selectionState === 'idle' && !statusMessage" class="product-display__marquee">
         <div class="marquee-track">
           <span>Select a product to start the sale · </span>
           <span>Select a product to start the sale · </span>
@@ -85,22 +97,16 @@
     </div>
 
     <div class="coin-slot">
-      <button
+      <CoinButton
         v-for="coin in dispensedCoins"
         :key="coin.id"
-        class="coin-slot__coin"
-        type="button"
-        @click="$emit('collect-coin', coin.id)"
-      >
-        {{ coin.label }}
-      </button>
+        :label="coin.label"
+        :value="coin.id"
+        :disabled="false"
+        @insert="$emit('collect-coin', coin.id)"
+      />
     </div>
 
-    <p v-if="error" class="inline-alert error">{{ error }}</p>
-    <p v-else-if="info" class="inline-alert info">{{ info }}</p>
-    <p v-else-if="alerts.outOfStock.length" class="inline-alert warning">
-      Out of stock: {{ alerts.outOfStock.join(', ') }}
-    </p>
   </aside>
 </template>
 
@@ -217,6 +223,36 @@ export default defineComponent({
         'product-display__status-value--positive': this.requirementTone === 'positive',
       }
     },
+    statusMessage(): string | null {
+      if (this.error) {
+        return this.error
+      }
+
+      if (this.info) {
+        return this.info
+      }
+
+      if (this.alerts.outOfStock.length) {
+        return `Out of stock: ${this.alerts.outOfStock.join(', ')}`
+      }
+
+      return null
+    },
+    statusTone(): 'error' | 'info' | 'warning' | null {
+      if (this.error) {
+        return 'error'
+      }
+
+      if (this.info) {
+        return 'info'
+      }
+
+      if (this.alerts.outOfStock.length) {
+        return 'warning'
+      }
+
+      return null
+    },
   },
   methods: {
     handleCoinButton(value: number): void {
@@ -323,6 +359,35 @@ export default defineComponent({
 
 .product-display__status-value--positive {
   color: #4ade80;
+}
+
+.product-display__message {
+  margin-top: 0.75rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+
+.product-display__message--error {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.product-display__message--info {
+  background: rgba(129, 140, 248, 0.18);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: #cdd5ff;
+}
+
+.product-display__message--warning {
+  background: rgba(251, 191, 36, 0.18);
+  border-color: rgba(251, 191, 36, 0.4);
+  color: #fde68a;
 }
 
 .product-display__marquee {
@@ -496,23 +561,6 @@ export default defineComponent({
   gap: 0.75rem;
   align-items: center;
   padding: 1rem;
-}
-
-.coin-slot__coin {
-  background: linear-gradient(160deg, #fbbf24 0%, #f97316 100%);
-  border: none;
-  border-radius: 999px;
-  padding: 0.4rem 0.9rem;
-  color: #0f172a;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 8px 16px rgba(249, 115, 22, 0.35);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.coin-slot__coin:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 20px rgba(249, 115, 22, 0.45);
 }
 
 .coin-animations {

--- a/frontend/src/modules/machine/components/MachineControlPanel.vue
+++ b/frontend/src/modules/machine/components/MachineControlPanel.vue
@@ -74,12 +74,30 @@
 
     <div class="actions">
       <button class="action primary" type="button" disabled>Buy product</button>
-      <button class="action secondary" type="button" disabled>Return coin</button>
+      <button
+        class="action secondary"
+        type="button"
+        :disabled="returnDisabled"
+        @click="$emit('return-coins')"
+      >
+        Return coins
+      </button>
     </div>
 
-    <div class="coin-slot"></div>
+    <div class="coin-slot">
+      <button
+        v-for="coin in dispensedCoins"
+        :key="coin.id"
+        class="coin-slot__coin"
+        type="button"
+        @click="$emit('collect-coin', coin.id)"
+      >
+        {{ coin.label }}
+      </button>
+    </div>
 
     <p v-if="error" class="inline-alert error">{{ error }}</p>
+    <p v-else-if="info" class="inline-alert info">{{ info }}</p>
     <p v-else-if="alerts.outOfStock.length" class="inline-alert warning">
       Out of stock: {{ alerts.outOfStock.join(', ') }}
     </p>
@@ -98,6 +116,12 @@ type CoinDefinition = {
 }
 
 type CoinAnimation = CoinDefinition & { id: number }
+
+export type DispensedCoin = {
+  id: number
+  label: string
+  value: number
+}
 
 const AVAILABLE_COINS: CoinDefinition[] = [
   { label: '€1.00', value: 100 },
@@ -161,12 +185,24 @@ export default defineComponent({
       type: String as PropType<string | null>,
       default: null,
     },
+    info: {
+      type: String as PropType<string | null>,
+      default: null,
+    },
     loading: {
       type: Boolean,
       default: false,
     },
+    returnDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    dispensedCoins: {
+      type: Array as PropType<DispensedCoin[]>,
+      default: () => [],
+    },
   },
-  emits: ['keypad', 'insert-coin'],
+  emits: ['keypad', 'insert-coin', 'return-coins', 'collect-coin'],
   data() {
     return {
       coins: AVAILABLE_COINS,
@@ -432,7 +468,7 @@ export default defineComponent({
   padding: 0.75rem 1.25rem;
   font-weight: 600;
   font-size: 1rem;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .action.primary {
@@ -445,11 +481,38 @@ export default defineComponent({
   color: #cbd5f5;
 }
 
+.action[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .coin-slot {
-  height: 160px;
+  min-height: 160px;
   border-radius: 18px;
   background: linear-gradient(180deg, #111827 0%, #050a13 100%);
   box-shadow: inset 0 18px 32px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 1rem;
+}
+
+.coin-slot__coin {
+  background: linear-gradient(160deg, #fbbf24 0%, #f97316 100%);
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(249, 115, 22, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.coin-slot__coin:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(249, 115, 22, 0.45);
 }
 
 .coin-animations {
@@ -474,6 +537,12 @@ export default defineComponent({
 .inline-alert.warning {
   background: rgba(251, 191, 36, 0.15);
   color: #fde68a;
+}
+
+.inline-alert.info {
+  background: rgba(129, 140, 248, 0.15);
+  border-color: rgba(129, 140, 248, 0.35);
+  color: #cdd5ff;
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/modules/machine/views/MachineDashboard.vue
+++ b/frontend/src/modules/machine/views/MachineDashboard.vue
@@ -323,7 +323,7 @@ export default defineComponent({
       const hasDispensedCoins = this.dispensedCoins.length > 0
 
       if (hasDispensedCoins) {
-        this.setInfo('Please collect your coins', 3000)
+        this.setInfo('Please collect your coins')
         return
       }
 
@@ -578,14 +578,11 @@ export default defineComponent({
       }
     },
     coinLabel(value: number): string {
-      const map: Record<number, string> = {
-        100: '€1.00',
-        25: '€0.25',
-        10: '€0.10',
-        5: '€0.05',
-      }
-
-      return map[value] ?? `${(value / 100).toFixed(2)} €`
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+      }).format(value / 100)
     },
     scheduleSelectionRevert(targetSlotCode: string): void {
       this.clearSelectionTimeout()

--- a/frontend/src/modules/machine/views/MachineDashboard.vue
+++ b/frontend/src/modules/machine/views/MachineDashboard.vue
@@ -31,9 +31,14 @@
         :keypad-buttons="keypadButtons"
         :alerts="alerts"
         :error="panelError"
+        :info="panelInfo"
         :loading="loading"
+        :return-disabled="returnButtonDisabled"
+        :dispensed-coins="dispensedCoins"
         @keypad="handleKeypadPress"
         @insert-coin="handleInsertCoin"
+        @return-coins="handleReturnCoins"
+        @collect-coin="collectReturnedCoin"
       />
     </div>
   </main>
@@ -52,7 +57,7 @@ import type {
 import { useMachineStore } from '@/modules/machine/store/useMachineStore'
 import MachineHeader from '@/modules/machine/components/MachineHeader.vue'
 import MachineProductGrid from '@/modules/machine/components/MachineProductGrid.vue'
-import MachineControlPanel from '@/modules/machine/components/MachineControlPanel.vue'
+import MachineControlPanel, { type DispensedCoin } from '@/modules/machine/components/MachineControlPanel.vue'
 
 export default defineComponent({
   name: 'MachineDashboard',
@@ -69,6 +74,12 @@ export default defineComponent({
       selectionTimeoutId: null as number | null,
       panelError: null as string | null,
       errorTimeoutId: null as number | null,
+      panelInfo: null as string | null,
+      infoTimeoutId: null as number | null,
+      returnInProgress: false,
+      returnCountdownId: null as number | null,
+      coinDispenseTimeoutId: null as number | null,
+      dispensedCoins: [] as DispensedCoin[],
     }
   },
   watch: {
@@ -90,6 +101,7 @@ export default defineComponent({
         this.clearErrorTimeout()
 
         if (newError) {
+          this.setInfo(null)
           this.panelError = newError
           this.errorTimeoutId = window.setTimeout(() => {
             this.panelError = null
@@ -105,6 +117,9 @@ export default defineComponent({
   beforeUnmount() {
     this.clearSelectionTimeout()
     this.clearErrorTimeout()
+    this.clearInfoTimeout()
+    this.clearReturnCountdown()
+    this.clearCoinDispenseTimeout()
   },
   computed: {
     ...mapStores(useMachineStore),
@@ -234,6 +249,23 @@ export default defineComponent({
         ['CLR', '0', 'OK'],
       ]
     },
+    canReturnCoins(): boolean {
+      if (this.dispensedCoins.length > 0) {
+        return true
+      }
+
+      if (!this.session) {
+        return false
+      }
+
+      const hasBalance = (this.session.balanceCents ?? 0) > 0
+      const hasInsertedCoins = Object.values(this.session.insertedCoins ?? {}).some((quantity) => quantity > 0)
+
+      return hasBalance || hasInsertedCoins
+    },
+    returnButtonDisabled(): boolean {
+      return this.loading || this.returnInProgress || !this.canReturnCoins
+    },
   },
   created() {
     this.machineStore.fetchMachineState()
@@ -281,6 +313,103 @@ export default defineComponent({
         await this.machineStore.insertCoin(coinValue)
       } catch (error) {
         console.error('Failed to insert coin', error)
+      }
+    },
+    async handleReturnCoins(): Promise<void> {
+      if (this.returnInProgress) {
+        return
+      }
+
+      const hasDispensedCoins = this.dispensedCoins.length > 0
+
+      if (hasDispensedCoins) {
+        this.setInfo('Please collect your coins', 3000)
+        return
+      }
+
+      if (!this.canReturnCoins) {
+        return
+      }
+
+      const ready = await this.ensureSessionReady()
+      if (!ready) {
+        return
+      }
+
+      this.returnInProgress = true
+      this.setInfo('Returning coins...')
+      this.clearReturnCountdown()
+
+      this.returnCountdownId = window.setTimeout(() => {
+        void this.executeReturnCoins()
+      }, 5000)
+    },
+    async executeReturnCoins(): Promise<void> {
+      this.clearReturnCountdown()
+
+      try {
+        const result = await this.machineStore.returnCoins()
+        this.enqueueReturnedCoins(result.returnedCoins)
+        this.selectedSlotCode = ''
+        this.lastConfirmedSlotCode = ''
+
+        const totalReturned = Object.values(result.returnedCoins).reduce((sum, quantity) => sum + quantity, 0)
+        if (totalReturned > 0) {
+          this.setInfo('Please collect your coins')
+        } else {
+          this.setInfo('No coins to return', 3000)
+        }
+      } catch (error) {
+        console.error('Failed to return coins', error)
+        this.setInfo(null)
+      } finally {
+        this.returnInProgress = false
+      }
+    },
+    enqueueReturnedCoins(returnedCoins: Record<number, number>): void {
+      const queue: DispensedCoin[] = []
+
+      const denominations = Object.keys(returnedCoins)
+        .map((value) => Number(value))
+        .filter((value) => returnedCoins[value] > 0)
+        .sort((a, b) => b - a)
+
+      denominations.forEach((value) => {
+        const quantity = returnedCoins[value]
+        for (let index = 0; index < quantity; index += 1) {
+          queue.push({
+            id: Date.now() + Math.floor(Math.random() * 1000) + index,
+            value,
+            label: this.coinLabel(value),
+          })
+        }
+      })
+
+      if (queue.length === 0) {
+        this.dispensedCoins = []
+        return
+      }
+
+      this.clearCoinDispenseTimeout()
+
+      const dispenseNext = () => {
+        const next = queue.shift()
+        if (!next) {
+          this.coinDispenseTimeoutId = null
+          return
+        }
+
+        this.dispensedCoins.push(next)
+        this.coinDispenseTimeoutId = window.setTimeout(dispenseNext, 400)
+      }
+
+      dispenseNext()
+    },
+    collectReturnedCoin(id: number): void {
+      this.dispensedCoins = this.dispensedCoins.filter((coin) => coin.id !== id)
+
+      if (this.dispensedCoins.length === 0 && !this.returnInProgress) {
+        this.setInfo(null)
       }
     },
     async ensureSessionReady(): Promise<boolean> {
@@ -375,6 +504,12 @@ export default defineComponent({
     async handleClearSelection(): Promise<void> {
       this.resetEnteredCode()
 
+      this.clearReturnCountdown()
+      this.clearCoinDispenseTimeout()
+      this.dispensedCoins = []
+      this.returnInProgress = false
+      this.setInfo(null)
+
       const hadSelection = Boolean(this.lastConfirmedSlotCode || this.selectedSlotCode)
 
       if (hadSelection) {
@@ -412,6 +547,45 @@ export default defineComponent({
         window.clearTimeout(this.errorTimeoutId)
         this.errorTimeoutId = null
       }
+    },
+    clearInfoTimeout(): void {
+      if (this.infoTimeoutId !== null) {
+        window.clearTimeout(this.infoTimeoutId)
+        this.infoTimeoutId = null
+      }
+    },
+    clearReturnCountdown(): void {
+      if (this.returnCountdownId !== null) {
+        window.clearTimeout(this.returnCountdownId)
+        this.returnCountdownId = null
+      }
+    },
+    clearCoinDispenseTimeout(): void {
+      if (this.coinDispenseTimeoutId !== null) {
+        window.clearTimeout(this.coinDispenseTimeoutId)
+        this.coinDispenseTimeoutId = null
+      }
+    },
+    setInfo(message: string | null, duration = 0): void {
+      this.clearInfoTimeout()
+      this.panelInfo = message
+
+      if (message && duration > 0) {
+        this.infoTimeoutId = window.setTimeout(() => {
+          this.panelInfo = null
+          this.infoTimeoutId = null
+        }, duration)
+      }
+    },
+    coinLabel(value: number): string {
+      const map: Record<number, string> = {
+        100: '€1.00',
+        25: '€0.25',
+        10: '€0.10',
+        5: '€0.05',
+      }
+
+      return map[value] ?? `${(value / 100).toFixed(2)} €`
     },
     scheduleSelectionRevert(targetSlotCode: string): void {
       this.clearSelectionTimeout()

--- a/frontend/tests/unit/modules/machine/store/useMachineStore.spec.ts
+++ b/frontend/tests/unit/modules/machine/store/useMachineStore.spec.ts
@@ -115,8 +115,8 @@ describe('useMachineStore', () => {
     const state = mockMachineState()
     state.session = {
       ...state.session!,
-      balanceCents: 150,
-      insertedCoins: { 100: 1, 50: 1 },
+      balanceCents: 125,
+      insertedCoins: { 100: 1, 25: 1 },
     }
 
     const returnResult = {
@@ -128,7 +128,7 @@ describe('useMachineStore', () => {
         selectedProductId: null,
         selectedSlotCode: null,
       },
-      returnedCoins: { 100: 1, 50: 1 },
+      returnedCoins: { 100: 1, 25: 1 },
     }
 
     vi.spyOn(returnCoinsApi, 'returnMachineCoins').mockResolvedValue(returnResult)
@@ -141,6 +141,6 @@ describe('useMachineStore', () => {
     expect(returnCoinsApi.returnMachineCoins).toHaveBeenCalledWith(state.session!.id)
     expect(store.machineState?.session?.balanceCents).toBe(0)
     expect(store.machineState?.session?.insertedCoins).toEqual({})
-    expect(response.returnedCoins).toEqual({ 100: 1, 50: 1 })
+    expect(response.returnedCoins).toEqual({ 100: 1, 25: 1 })
   })
 })

--- a/frontend/tests/unit/modules/machine/store/useMachineStore.spec.ts
+++ b/frontend/tests/unit/modules/machine/store/useMachineStore.spec.ts
@@ -4,6 +4,7 @@ import { useMachineStore } from '@/modules/machine/store/useMachineStore'
 import type { MachineState } from '@/modules/machine/api/getMachineState'
 import * as machineApi from '@/modules/machine/api/getMachineState'
 import * as insertCoinApi from '@/modules/machine/api/insertMachineCoin'
+import * as returnCoinsApi from '@/modules/machine/api/returnMachineCoins'
 import * as startSessionApi from '@/modules/machine/api/startMachineSession'
 
 const mockMachineState = (): MachineState => ({
@@ -108,5 +109,38 @@ describe('useMachineStore', () => {
     store.clearError()
 
     expect(store.error).toBeNull()
+  })
+
+  it('returns coins and updates session state', async () => {
+    const state = mockMachineState()
+    state.session = {
+      ...state.session!,
+      balanceCents: 150,
+      insertedCoins: { 100: 1, 50: 1 },
+    }
+
+    const returnResult = {
+      machineId: 'vm-001',
+      session: {
+        ...state.session,
+        balanceCents: 0,
+        insertedCoins: {},
+        selectedProductId: null,
+        selectedSlotCode: null,
+      },
+      returnedCoins: { 100: 1, 50: 1 },
+    }
+
+    vi.spyOn(returnCoinsApi, 'returnMachineCoins').mockResolvedValue(returnResult)
+
+    const store = useMachineStore()
+    store.machineState = state
+
+    const response = await store.returnCoins()
+
+    expect(returnCoinsApi.returnMachineCoins).toHaveBeenCalledWith(state.session!.id)
+    expect(store.machineState?.session?.balanceCents).toBe(0)
+    expect(store.machineState?.session?.insertedCoins).toEqual({})
+    expect(response.returnedCoins).toEqual({ 100: 1, 50: 1 })
   })
 })


### PR DESCRIPTION
- Overlayed status messaging inside the product display: any error/info/warning now appears in a full-screen overlay consistent with the “Product unavailable” styling.

- Reused CoinButton for returned coins so dispensed pieces share the same look-and-feel as insertable coins, with the slot layout adjusted to host those buttons.

- Updated the dashboard to pass the new props/events and fixed TS typing around return-button enablement.

- Adjusted the store test expectation to match the new API return structure for coin returns.