### PR TITLE
test: use mothers to build vending fixtures

### DIFF
--- a/backend/tests/Unit/VendingMachine/CoinInventory/Domain/Service/ChangeAvailabilityCheckerTest.php
+++ b/backend/tests/Unit/VendingMachine/CoinInventory/Domain/Service/ChangeAvailabilityCheckerTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\VendingMachine\CoinInventory\Domain\Service;
 
-use App\VendingMachine\CoinInventory\Domain\CoinInventory;
+use App\Tests\Unit\VendingMachine\CoinInventory\Domain\CoinInventoryMother;
 use App\VendingMachine\CoinInventory\Domain\Service\ChangeAvailabilityChecker;
-use App\VendingMachine\CoinInventory\Domain\ValueObject\CoinBundle;
 use PHPUnit\Framework\TestCase;
 
 final class ChangeAvailabilityCheckerTest extends TestCase
@@ -20,38 +19,29 @@ final class ChangeAvailabilityCheckerTest extends TestCase
 
     public function testItReportsChangeAsSufficientWhenEnoughCoinsAreAvailable(): void
     {
-        $inventory = CoinInventory::restore(
-            CoinBundle::fromArray([
-                25 => 4,
-                10 => 5,
-                5 => 5,
-            ]),
-            CoinBundle::empty()
-        );
+        $inventory = CoinInventoryMother::withAvailable([
+            25 => 4,
+            10 => 5,
+            5 => 5,
+        ]);
 
         self::assertTrue($this->checker->isChangeSufficient($inventory));
     }
 
     public function testItReportsChangeAsInsufficientWhenNoChangeCoinsExist(): void
     {
-        $inventory = CoinInventory::restore(
-            CoinBundle::fromArray([
-                100 => 10,
-            ]),
-            CoinBundle::empty()
-        );
+        $inventory = CoinInventoryMother::withAvailable([
+            100 => 10,
+        ]);
 
         self::assertFalse($this->checker->isChangeSufficient($inventory));
     }
 
     public function testItReportsChangeAsInsufficientWhenExactAmountsCannotBeMade(): void
     {
-        $inventory = CoinInventory::restore(
-            CoinBundle::fromArray([
-                10 => 10,
-            ]),
-            CoinBundle::empty()
-        );
+        $inventory = CoinInventoryMother::withAvailable([
+            10 => 10,
+        ]);
 
         self::assertFalse($this->checker->isChangeSufficient($inventory));
     }

--- a/backend/tests/Unit/VendingMachine/Inventory/Application/GetSlots/AdminGetSlotsQueryHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Inventory/Application/GetSlots/AdminGetSlotsQueryHandlerTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Tests\Unit\VendingMachine\Inventory\Application\GetSlots;
 
 use App\Shared\Money\Domain\Money;
+use App\Tests\Unit\VendingMachine\Inventory\Domain\InventorySlotMother;
+use App\Tests\Unit\VendingMachine\Product\Domain\ProductMother;
 use App\VendingMachine\Inventory\Application\GetSlots\AdminGetSlotsQuery;
 use App\VendingMachine\Inventory\Application\GetSlots\AdminGetSlotsQueryHandler;
 use App\VendingMachine\Inventory\Application\GetSlots\AdminSlotsInventoryResult;
-use App\VendingMachine\Inventory\Domain\InventorySlot;
 use App\VendingMachine\Inventory\Domain\InventorySlotRepository;
 use App\VendingMachine\Inventory\Domain\ValueObject\InventorySlotId;
 use App\VendingMachine\Inventory\Domain\ValueObject\RestockThreshold;
@@ -16,7 +17,6 @@ use App\VendingMachine\Inventory\Domain\ValueObject\SlotCapacity;
 use App\VendingMachine\Inventory\Domain\ValueObject\SlotCode;
 use App\VendingMachine\Inventory\Domain\ValueObject\SlotQuantity;
 use App\VendingMachine\Inventory\Domain\ValueObject\SlotStatus;
-use App\VendingMachine\Product\Domain\Product;
 use App\VendingMachine\Product\Domain\ProductRepository;
 use App\VendingMachine\Product\Domain\ValueObject\ProductId;
 use App\VendingMachine\Product\Domain\ValueObject\ProductName;
@@ -29,14 +29,14 @@ final class AdminGetSlotsQueryHandlerTest extends TestCase
 {
     public function testMapsSlotsWithProductInformation(): void
     {
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(4),
-            RestockThreshold::fromInt(2),
-            SlotStatus::Available,
-            ProductId::fromString('product-1'),
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(4),
+            restockThreshold: RestockThreshold::fromInt(2),
+            status: SlotStatus::Available,
+            productId: ProductId::fromString('product-1'),
         );
 
         $slotRepository = $this->createMock(InventorySlotRepository::class);
@@ -45,13 +45,13 @@ final class AdminGetSlotsQueryHandlerTest extends TestCase
             ->with('machine-1')
             ->willReturn([$slot]);
 
-        $product = Product::create(
-            ProductId::fromString('product-1'),
-            ProductSku::fromString('SKU-001'),
-            ProductName::fromString('Water'),
-            Money::fromCents(65),
-            ProductStatus::Active,
-            RecommendedSlotQuantity::fromInt(8),
+        $product = ProductMother::random(
+            id: ProductId::fromString('product-1'),
+            sku: ProductSku::fromString('SKU-001'),
+            name: ProductName::fromString('Water'),
+            price: Money::fromCents(65),
+            status: ProductStatus::Active,
+            recommendedSlotQuantity: RecommendedSlotQuantity::fromInt(8),
         );
 
         $productRepository = $this->createMock(ProductRepository::class);

--- a/backend/tests/Unit/VendingMachine/Inventory/Infrastructure/Mongo/MongoInventorySlotRepositoryTest.php
+++ b/backend/tests/Unit/VendingMachine/Inventory/Infrastructure/Mongo/MongoInventorySlotRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\VendingMachine\Inventory\Infrastructure\Mongo;
 
+use App\Tests\Unit\VendingMachine\Inventory\Domain\InventorySlotMother;
 use App\VendingMachine\Inventory\Domain\InventorySlot;
 use App\VendingMachine\Inventory\Domain\ValueObject\InventorySlotId;
 use App\VendingMachine\Inventory\Domain\ValueObject\RestockThreshold;
@@ -71,14 +72,14 @@ final class MongoInventorySlotRepositoryTest extends TestCase
 
         $repository = new MongoInventorySlotRepository($documentManager);
 
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(5),
-            RestockThreshold::fromInt(2),
-            SlotStatus::Available,
-            ProductId::fromString('product-1'),
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(5),
+            restockThreshold: RestockThreshold::fromInt(2),
+            status: SlotStatus::Available,
+            productId: ProductId::fromString('product-1'),
         );
 
         $repository->save($slot, 'machine-1');
@@ -111,14 +112,13 @@ final class MongoInventorySlotRepositoryTest extends TestCase
 
         $repository = new MongoInventorySlotRepository($documentManager);
 
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(3),
-            RestockThreshold::fromInt(2),
-            SlotStatus::Reserved,
-            null,
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(3),
+            restockThreshold: RestockThreshold::fromInt(2),
+            status: SlotStatus::Reserved,
         );
 
         $repository->save($slot, 'machine-1');

--- a/backend/tests/Unit/VendingMachine/Product/Infrastructure/Mongo/MongoProductRepositoryTest.php
+++ b/backend/tests/Unit/VendingMachine/Product/Infrastructure/Mongo/MongoProductRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\VendingMachine\Product\Infrastructure\Mongo;
 
 use App\Shared\Money\Domain\Money;
+use App\Tests\Unit\VendingMachine\Product\Domain\ProductMother;
 use App\VendingMachine\Product\Domain\Product;
 use App\VendingMachine\Product\Domain\ValueObject\ProductId;
 use App\VendingMachine\Product\Domain\ValueObject\ProductName;
@@ -66,7 +67,14 @@ final class MongoProductRepositoryTest extends TestCase
             ->method('flush');
 
         $repository = new MongoProductRepository($documentManager);
-        $product = $this->createProduct('product-1', 'SKU-001', 'Water', 65);
+        $product = ProductMother::random(
+            id: ProductId::fromString('product-1'),
+            sku: ProductSku::fromString('SKU-001'),
+            name: ProductName::fromString('Water'),
+            price: Money::fromCents(65),
+            status: ProductStatus::Active,
+            recommendedSlotQuantity: RecommendedSlotQuantity::fromInt(8),
+        );
 
         $repository->save($product);
     }
@@ -95,7 +103,14 @@ final class MongoProductRepositoryTest extends TestCase
             ->method('flush');
 
         $repository = new MongoProductRepository($documentManager);
-        $updated = $this->createProduct('product-1', 'SKU-NEW', 'New Name', 150);
+        $updated = ProductMother::random(
+            id: ProductId::fromString('product-1'),
+            sku: ProductSku::fromString('SKU-NEW'),
+            name: ProductName::fromString('New Name'),
+            price: Money::fromCents(150),
+            status: ProductStatus::Active,
+            recommendedSlotQuantity: RecommendedSlotQuantity::fromInt(8),
+        );
 
         $repository->save($updated);
 
@@ -161,17 +176,5 @@ final class MongoProductRepositoryTest extends TestCase
 
         self::assertCount(2, $products);
         self::assertSame(['product-1', 'product-2'], array_map(static fn (Product $product): string => $product->id()->value(), $products));
-    }
-
-    private function createProduct(string $id, string $sku, string $name, int $priceCents): Product
-    {
-        return Product::create(
-            ProductId::fromString($id),
-            ProductSku::fromString($sku),
-            ProductName::fromString($name),
-            Money::fromCents($priceCents),
-            ProductStatus::Active,
-            RecommendedSlotQuantity::fromInt(8),
-        );
     }
 }

--- a/backend/tests/Unit/VendingMachine/Session/Application/ClearSelection/ClearSelectionCommandHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Session/Application/ClearSelection/ClearSelectionCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\VendingMachine\Session\Application\ClearSelection;
 
+use App\Tests\Unit\VendingMachine\Inventory\Domain\InventorySlotMother;
 use App\VendingMachine\Inventory\Domain\InventorySlot;
 use App\VendingMachine\Inventory\Domain\InventorySlotRepository;
 use App\VendingMachine\Inventory\Domain\ValueObject\InventorySlotId;
@@ -67,14 +68,13 @@ final class ClearSelectionCommandHandlerTest extends TestCase
         $documentManager->expects(self::once())
             ->method('flush');
 
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(5),
-            RestockThreshold::fromInt(2),
-            SlotStatus::Reserved,
-            null,
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(5),
+            restockThreshold: RestockThreshold::fromInt(2),
+            status: SlotStatus::Reserved,
         );
 
         $slotRepository = $this->createMock(InventorySlotRepository::class);

--- a/backend/tests/Unit/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommandHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Session/Application/ReturnCoins/ReturnCoinsCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\VendingMachine\Session\Application\ReturnCoins;
 
+use App\Tests\Unit\VendingMachine\Inventory\Domain\InventorySlotMother;
 use App\VendingMachine\Inventory\Domain\InventorySlot;
 use App\VendingMachine\Inventory\Domain\InventorySlotRepository;
 use App\VendingMachine\Inventory\Domain\ValueObject\InventorySlotId;
@@ -67,14 +68,13 @@ final class ReturnCoinsCommandHandlerTest extends TestCase
         $documentManager->expects(self::once())
             ->method('flush');
 
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(6),
-            RestockThreshold::fromInt(2),
-            SlotStatus::Reserved,
-            null,
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(6),
+            restockThreshold: RestockThreshold::fromInt(2),
+            status: SlotStatus::Reserved,
         );
 
         $slotRepository = $this->createMock(InventorySlotRepository::class);

--- a/backend/tests/Unit/VendingMachine/Session/Application/SelectProductCommandHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Session/Application/SelectProductCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\VendingMachine\Session\Application;
 
+use App\Tests\Unit\VendingMachine\Inventory\Domain\InventorySlotMother;
 use App\VendingMachine\Inventory\Domain\InventorySlot;
 use App\VendingMachine\Inventory\Domain\InventorySlotRepository;
 use App\VendingMachine\Inventory\Domain\ValueObject\InventorySlotId;
@@ -56,14 +57,13 @@ final class SelectProductCommandHandlerTest extends TestCase
         $documentManager->expects(self::once())
             ->method('flush');
 
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(5),
-            RestockThreshold::fromInt(2),
-            SlotStatus::Available,
-            null,
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(5),
+            restockThreshold: RestockThreshold::fromInt(2),
+            status: SlotStatus::Available,
         );
 
         $slotRepository = $this->createMock(InventorySlotRepository::class);

--- a/backend/tests/Unit/VendingMachine/Session/Application/VendProduct/VendProductCommandHandlerTest.php
+++ b/backend/tests/Unit/VendingMachine/Session/Application/VendProduct/VendProductCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\VendingMachine\Session\Application\VendProduct;
 
+use App\Tests\Unit\VendingMachine\Inventory\Domain\InventorySlotMother;
 use App\VendingMachine\CoinInventory\Domain\CoinInventoryRepository;
 use App\VendingMachine\CoinInventory\Domain\CoinInventorySnapshot;
 use App\VendingMachine\CoinInventory\Domain\Service\ChangeAvailabilityChecker;
@@ -205,14 +206,13 @@ final class VendProductCommandHandlerTest extends TestCase
         $documentManager->expects(self::once())
             ->method('flush');
 
-        $slot = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(2),
-            RestockThreshold::fromInt(1),
-            SlotStatus::Reserved,
-            null,
+        $slot = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(2),
+            restockThreshold: RestockThreshold::fromInt(1),
+            status: SlotStatus::Reserved,
         );
 
         $slotRepository = $this->createMock(InventorySlotRepository::class);
@@ -349,14 +349,14 @@ final class VendProductCommandHandlerTest extends TestCase
                 return 1 === ($snapshot->available[100] ?? 0);
             }));
 
-        $slotAggregate = InventorySlot::restore(
-            InventorySlotId::fromString('slot-1'),
-            SlotCode::fromString('11'),
-            SlotCapacity::fromInt(10),
-            SlotQuantity::fromInt(2),
-            RestockThreshold::fromInt(1),
-            SlotStatus::Available,
-            ProductId::fromString('product-1'),
+        $slotAggregate = InventorySlotMother::random(
+            id: InventorySlotId::fromString('slot-1'),
+            code: SlotCode::fromString('11'),
+            capacity: SlotCapacity::fromInt(10),
+            quantity: SlotQuantity::fromInt(2),
+            restockThreshold: RestockThreshold::fromInt(1),
+            status: SlotStatus::Available,
+            productId: ProductId::fromString('product-1'),
         );
 
         $slotRepository = $this->createMock(InventorySlotRepository::class);


### PR DESCRIPTION
- Swapped the manual InventorySlot, Product, and CoinInventory fixtures in unit tests for their respective mothers so domain objects are built consistently while mocks stay focused on external dependencies.

- Updated the session command handler tests (select, clear, return coins, vend product), Mongo repositories, and the change-availability checks to rely on those mothers instead of hand-crafted aggregates.