### PR TITLE
fix: clear slot product when stock is depleted

### DIFF
--- a/backend/src/VendingMachine/Session/Application/VendProduct/VendProductCommandHandler.php
+++ b/backend/src/VendingMachine/Session/Application/VendProduct/VendProductCommandHandler.php
@@ -239,6 +239,9 @@ final class VendProductCommandHandler
             $slotAggregate->removeStock(1);
             if ($slotAggregate->quantity()->isZero()) {
                 $slotAggregate->disable();
+                if ($slotAggregate->hasProductAssigned()) {
+                    $slotAggregate->clearProduct();
+                }
             } else {
                 $slotAggregate->markAvailable();
             }


### PR DESCRIPTION
- When a vend removes the last unit from a slot, we now call clearProduct() in addition to disable() so the aggregate no longer reports a stale product.

- The machine state provider stops flagging the product as “out_of_stock” after the slot is emptied, matching the disabled state.