### PR TITLE
test: configure symfony kernel for smoke tests

### DIFF
--- a/backend/phpunit.dist.xml
+++ b/backend/phpunit.dist.xml
@@ -15,6 +15,7 @@
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="KERNEL_CLASS" value="App\Kernel" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
Added KERNEL_CLASS=App\Kernel to backend/phpunit.dist.xml so Symfony’s WebTestCase can boot the kernel during smoke tests without manual overrides.