### PR TITLE
feat(admin): expose product catalog for slot restocking

### DIFF
--- a/backend/config/routes.yaml
+++ b/backend/config/routes.yaml
@@ -32,3 +32,10 @@ admin_inventory_controllers:
         namespace: App\AdminPanel\Inventory\UI\Http\Controller
     type: attribute
     prefix: /api/admin
+
+admin_product_controllers:
+    resource:
+        path: ../src/AdminPanel/Product/UI/Http/Controller/
+        namespace: App\AdminPanel\Product\UI\Http\Controller
+    type: attribute
+    prefix: /api/admin

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -48,6 +48,10 @@ services:
         bind:
             $defaultMachineId: '%app.machine_id%'
 
+    App\AdminPanel\Product\UI\Http\Controller\:
+        resource: '../src/AdminPanel/Product/UI/Http/Controller/'
+        public: true
+
     App\VendingMachine\CoinInventory\Domain\CoinInventoryRepository: '@App\VendingMachine\CoinInventory\Infrastructure\Mongo\MongoCoinInventoryRepository'
 
     App\VendingMachine\CoinInventory\Domain\Service\ChangeAvailabilityChecker: ~

--- a/backend/src/AdminPanel/Product/Application/GetProducts/AdminGetProductsQuery.php
+++ b/backend/src/AdminPanel/Product/Application/GetProducts/AdminGetProductsQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AdminPanel\Product\Application\GetProducts;
+
+final class AdminGetProductsQuery
+{
+}

--- a/backend/src/AdminPanel/Product/Application/GetProducts/AdminGetProductsQueryHandler.php
+++ b/backend/src/AdminPanel/Product/Application/GetProducts/AdminGetProductsQueryHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AdminPanel\Product\Application\GetProducts;
+
+use App\VendingMachine\Product\Domain\ProductRepository;
+
+final class AdminGetProductsQueryHandler
+{
+    public function __construct(private readonly ProductRepository $repository)
+    {
+    }
+
+    public function handle(AdminGetProductsQuery $query): AdminProductsResult
+    {
+        $products = array_map(
+            static fn ($product) => new AdminProductView(
+                id: $product->id()->value(),
+                name: $product->name()->value(),
+                priceCents: $product->price()->amountInCents(),
+                status: $product->status()->value,
+                recommendedSlotQuantity: $product->recommendedSlotQuantity()->value(),
+            ),
+            array_filter(
+                $this->repository->all(),
+                static fn ($product) => $product->status()->isActive(),
+            ),
+        );
+
+        return new AdminProductsResult(array_values($products));
+    }
+}

--- a/backend/src/AdminPanel/Product/Application/GetProducts/AdminProductView.php
+++ b/backend/src/AdminPanel/Product/Application/GetProducts/AdminProductView.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AdminPanel\Product\Application\GetProducts;
+
+final class AdminProductView
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly ?int $priceCents,
+        public readonly string $status,
+        public readonly ?int $recommendedSlotQuantity,
+    ) {
+    }
+}

--- a/backend/src/AdminPanel/Product/Application/GetProducts/AdminProductsResult.php
+++ b/backend/src/AdminPanel/Product/Application/GetProducts/AdminProductsResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AdminPanel\Product\Application\GetProducts;
+
+final class AdminProductsResult
+{
+    /**
+     * @param AdminProductView[] $products
+     */
+    public function __construct(
+        public readonly array $products,
+    ) {
+    }
+}

--- a/backend/src/AdminPanel/Product/UI/Http/Controller/GetProductCatalogController.php
+++ b/backend/src/AdminPanel/Product/UI/Http/Controller/GetProductCatalogController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AdminPanel\Product\UI\Http\Controller;
+
+use App\AdminPanel\Product\Application\GetProducts\AdminGetProductsQuery;
+use App\AdminPanel\Product\Application\GetProducts\AdminGetProductsQueryHandler;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/products', name: 'admin_products_catalog', methods: ['GET'])]
+final class GetProductCatalogController
+{
+    public function __construct(private readonly AdminGetProductsQueryHandler $handler)
+    {
+    }
+
+    public function __invoke(): JsonResponse
+    {
+        $result = $this->handler->handle(new AdminGetProductsQuery());
+
+        return new JsonResponse([
+            'products' => array_map(
+                static fn ($product) => [
+                    'id' => $product->id,
+                    'name' => $product->name,
+                    'priceCents' => $product->priceCents,
+                    'status' => $product->status,
+                    'recommendedSlotQuantity' => $product->recommendedSlotQuantity,
+                ],
+                $result->products,
+            ),
+        ]);
+    }
+}

--- a/frontend/src/modules/admin/api/getProducts.ts
+++ b/frontend/src/modules/admin/api/getProducts.ts
@@ -1,0 +1,18 @@
+import { getJson } from '@/core/api/httpClient'
+
+export interface AdminProductOption {
+  id: string
+  name: string
+  priceCents: number | null
+  status: 'active' | 'inactive'
+  recommendedSlotQuantity: number | null
+}
+
+interface AdminProductCatalogResponse {
+  products: AdminProductOption[]
+}
+
+export function getAdminProducts(): Promise<AdminProductCatalogResponse> {
+  return getJson<AdminProductCatalogResponse>('/admin/products')
+}
+

--- a/frontend/src/modules/admin/components/AdminInventorySection.vue
+++ b/frontend/src/modules/admin/components/AdminInventorySection.vue
@@ -268,6 +268,11 @@ watch(operation, () => {
 watch(productSelectionVisible, (visible) => {
   if (!visible) {
     selectedProductId.value = ''
+    return
+  }
+
+  if (!selectedProductId.value && productOptions.value.length > 0) {
+    selectedProductId.value = productOptions.value[0].id
   }
 })
 


### PR DESCRIPTION
What Changed

- Fix edge case where an empty vending machine left the admin restock flow without product options: added GET /api/admin/products, backed by a new application query, to serve the full active catalog directly from Mongo.

- Wired the controller into the Symfony container and exposed the route under /api/admin/products.

- Updated the admin inventory store/component to fetch this catalog, populate the dropdown even when all slots are empty, and auto-select a product when assigning a slot.

- Added a typed frontend API helper (getAdminProducts) used by the Pinia store.

How to Test

- In the admin UI, set all slots to zero stock; the restock form should now display the available products and allow assigning one to an empty slot.